### PR TITLE
Add get_name to retrieve human-readable Tz names

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -88,22 +88,24 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) {
 }}\n\n").unwrap();
 
     write!(timezone_file,
-"pub fn get_name(tz: &Tz) -> &'static str {{
-    match *tz {{\n").unwrap();
+"impl Tz {{
+    pub fn name(self: &Tz) -> &'static str {{
+        match *self {{\n").unwrap();
     for zone in &zones {
         let zone_name = convert_bad_chars(zone);
         write!(timezone_file,
-               "        Tz::{zone} => \"{raw_zone_name}\",\n",
+               "            Tz::{zone} => \"{raw_zone_name}\",\n",
                zone = zone_name,
                raw_zone_name = zone).unwrap();
     }
     write!(timezone_file,
-"    }}
+"        }}
+    }}
 }}\n\n").unwrap();
     write!(timezone_file,
 "impl Debug for Tz {{
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {{
-        write!(f, \"{{}}\", get_name(&self))
+        write!(f, \"{{}}\", self.name())
     }}
 }}\n\n").unwrap();
     write!(timezone_file,

--- a/build.rs
+++ b/build.rs
@@ -81,25 +81,29 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) {
                zone = zone_name,
                raw_zone_name = zone).unwrap();
     }
-    write!(timezone_file, 
+    write!(timezone_file,
 "             s => Err(s.to_string())
         }}
     }}
 }}\n\n").unwrap();
 
     write!(timezone_file,
-"impl Debug for Tz {{
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {{
-        match *self {{\n").unwrap();
+"pub fn get_name(tz: &Tz) -> &'static str {{
+    match *tz {{\n").unwrap();
     for zone in &zones {
         let zone_name = convert_bad_chars(zone);
         write!(timezone_file,
-               "            Tz::{zone} => write!(f, \"{raw_zone_name}\"),\n",
+               "        Tz::{zone} => \"{raw_zone_name}\",\n",
                zone = zone_name,
                raw_zone_name = zone).unwrap();
     }
     write!(timezone_file,
-"         }}
+"    }}
+}}\n\n").unwrap();
+    write!(timezone_file,
+"impl Debug for Tz {{
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {{
+        write!(f, \"{{}}\", get_name(&self))
     }}
 }}\n\n").unwrap();
     write!(timezone_file,
@@ -110,7 +114,7 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) {
         let timespans = table.timespans(&zone).unwrap();
         let zone_name = convert_bad_chars(zone);
         write!(
-            timezone_file, 
+            timezone_file,
 "            Tz::{zone} => {{
                 const REST: &'static [(i64, FixedTimespan)] = {rest};
                 FixedTimespanSet {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 //! # extern crate chrono_tz;
 //! use chrono::TimeZone;
 //! use chrono_tz::Asia::Kolkata;
-//! 
+//!
 //! # fn main() {
 //! let dt = Kolkata.ymd(2000, 1, 1).and_hms(0, 0, 0);
 //! let timestamp = dt.timestamp();
@@ -114,7 +114,7 @@
 //! # extern crate chrono_tz;
 //! use chrono::TimeZone;
 //! use chrono_tz::Europe::London;
-//! 
+//!
 //! # fn main() {
 //! let dt = London.ymd(2016, 5, 10).and_hms(12, 0, 0);
 //! assert_eq!(dt.to_string(), "2016-05-10 12:00:00 BST");
@@ -123,14 +123,14 @@
 //! ```
 //!
 //! You can convert a timezone string to a timezone using the FromStr trait
-//! 
+//!
 //! ```
 //! # extern crate chrono;
 //! # extern crate chrono_tz;
 //! use chrono::TimeZone;
 //! use chrono_tz::Tz;
 //! use chrono_tz::UTC;
-//! 
+//!
 //! # fn main() {
 //! let tz: Tz = "Antarctica/South_Pole".parse().unwrap();
 //! let dt = tz.ymd(2016, 10, 22).and_hms(12, 0, 0);
@@ -147,7 +147,7 @@ mod timezones;
 mod directory;
 
 pub use directory::*;
-pub use timezones::Tz;
+pub use timezones::{Tz, get_name};
 
 #[cfg(test)]
 mod tests {
@@ -165,6 +165,8 @@ mod tests {
     use super::Pacific::Noumea;
     use super::Pacific::Tahiti;
     use super::US::Eastern;
+    use super::Tz;
+    use super::get_name;
     use chrono::{TimeZone, Duration};
 
     #[test]
@@ -361,5 +363,13 @@ mod tests {
     #[test]
     fn unambiguous_time_2() {
         let _ = Moscow.ymd(2014, 10, 26).and_hms(2, 0, 0);
+    }
+
+    #[test]
+    fn test_get_name() {
+        assert_eq!(get_name(&London), "Europe/London");
+        assert_eq!(get_name(&Tz::Africa__Abidjan), "Africa/Abidjan");
+        assert_eq!(get_name(&Tz::UTC), "UTC");
+        assert_eq!(get_name(&Tz::Zulu), "Zulu");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ mod timezones;
 mod directory;
 
 pub use directory::*;
-pub use timezones::{Tz, get_name};
+pub use timezones::Tz;
 
 #[cfg(test)]
 mod tests {
@@ -166,7 +166,6 @@ mod tests {
     use super::Pacific::Tahiti;
     use super::US::Eastern;
     use super::Tz;
-    use super::get_name;
     use chrono::{TimeZone, Duration};
 
     #[test]
@@ -367,9 +366,9 @@ mod tests {
 
     #[test]
     fn test_get_name() {
-        assert_eq!(get_name(&London), "Europe/London");
-        assert_eq!(get_name(&Tz::Africa__Abidjan), "Africa/Abidjan");
-        assert_eq!(get_name(&Tz::UTC), "UTC");
-        assert_eq!(get_name(&Tz::Zulu), "Zulu");
+        assert_eq!(London.name(), "Europe/London");
+        assert_eq!(Tz::Africa__Abidjan.name(), "Africa/Abidjan");
+        assert_eq!(Tz::UTC.name(), "UTC");
+        assert_eq!(Tz::Zulu.name(), "Zulu");
     }
 }


### PR DESCRIPTION
Fixes #6.

Sorry, but it seems that some whitespace changes also made it through. I can get rid of those if they bother you.